### PR TITLE
Use mmap instead of reading the image file

### DIFF
--- a/jpylyzer/jpylyzer.py
+++ b/jpylyzer/jpylyzer.py
@@ -32,6 +32,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import mmap
 import os
 import time
 import imp
@@ -263,9 +264,17 @@ def generatePropertiesRemapTable():
 def checkOneFile(file):
     # Process one file and return analysis result as element object
 
-    fileData = readFileBytes(file)
+    # fileData = readFileBytes(file)
+
+    f = open(file, "rb")
+
+    fileData = mmap.mmap(f.fileno(), 0, mmap.MAP_SHARED, mmap.PROT_READ)
+
     isValidJP2, tests, characteristics = BoxValidator(
         "JP2", fileData).validate()  # validateJP2(fileData)
+
+    fileData.close()
+    f.close()
 
     # Generate property values remap table
     remapTable = generatePropertiesRemapTable()


### PR DESCRIPTION
This patch tries to address issue #32. It is only a proof of concept, not meant to be pulled.
Comments welcome.

Regards
Stefan


This is experimental code which will only work on Linux because
Windows uses different parameters for mmap.

Instead of reading the whole image file into memory, mmap is used to
map the file into memory. Only those parts of the file which are accessed
will be read from disk.

In theory, this should allow very large files on 64 bit operating systems.
32 bit operating systems are still limited to the mappable memory which
is less than 4 GiB, typically even less than 2 GiB.

Signed-off-by: Stefan Weil <sw@weilnetz.de>