### PR TITLE
Fix build error on Travis (#65)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.3"
 
 before_install:
-  - sudo pip install --use-mirrors pyinstaller
+  - sudo pip install pyinstaller
 
 install:
   - dpkg-buildpackage -tc -uc -us

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.3"
 
 before_install:
-  - sudo pip install pyinstaller
+  - sudo -H pip install pyinstaller
 
 install:
   - dpkg-buildpackage -tc -uc -us

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo pip install --use-mirrors pyinstaller
 
 install:
-  - dpkg-buildpackage -tc
+  - dpkg-buildpackage -tc -uc -us
 
 script:
   - python -m unittest discover

--- a/build-with-pyinstaller.sh
+++ b/build-with-pyinstaller.sh
@@ -6,7 +6,7 @@
 command -v pyinstaller >/dev/null 2>&1 || {
     echo >&2 "http://www.pyinstaller.org/ is required to build the Jpylyzer executable.";
     echo >&2 "Please install PyInstaller http://pythonhosted.org/PyInstaller/#installing-pyinstaller.";
-    exit 1; 
+    exit 1;
 }
 
 # PyInstaller cannot be run as root
@@ -15,13 +15,13 @@ userId=$originalUserId
 
 if [ $originalUserId == 0 ]
 then
-	uname=$(getent passwd 1000 | cut -d: -f1)
-	sudo -u $uname "pyi-makespec --strip --onefile --specpath=pyi-build ./jpylyzer/jpylyzer.py;"
-	sudo -u $uname "pyinstaller --strip --clean --distpath=pyi-build/dist --workpath=pyi-build/build ./pyi-build/jpylyzer.spec;"
+    uname=$(getent passwd 1000 | cut -d: -f1)
+    sudo -u $uname "pyi-makespec --strip --onefile --paths=jpylyzer --specpath=pyi-build ./jpylyzer/jpylyzer.py"
+    sudo -u $uname "pyinstaller --strip --clean --paths=jpylyzer --distpath=pyi-build/dist --workpath=pyi-build/build ./pyi-build/jpylyzer.spec"
 else
-	# So making stripped binaries for debian packaging
-	pyi-makespec --strip --onefile --specpath=pyi-build ./jpylyzer/jpylyzer.py;
-	pyinstaller --strip --clean --distpath=pyi-build/dist --workpath=pyi-build/build ./pyi-build/jpylyzer.spec;
+    # So making stripped binaries for debian packaging
+    pyi-makespec --strip --onefile --paths=jpylyzer --specpath=pyi-build ./jpylyzer/jpylyzer.py
+    pyinstaller --strip --clean --paths=jpylyzer --distpath=pyi-build/dist --workpath=pyi-build/build ./pyi-build/jpylyzer.spec
 fi
 
 ./pyi-build/dist/jpylyzer --version;


### PR DESCRIPTION
It was caused because pyinstaller did not include the modules
needed for jpylyzer.py. Adding the path to these modules helps.

Signed-off-by: Stefan Weil <sw@weilnetz.de>