### PR TITLE
skip ISO-8859-15 validation for rcom=0

### DIFF
--- a/jpylyzer/boxvalidator.py
+++ b/jpylyzer/boxvalidator.py
@@ -1779,9 +1779,15 @@ class BoxValidator:
         rcomIsValid = 0 <= rcom <= 1
         self.testFor("rcomIsValid", rcomIsValid)
 
-        if rcom == 1:
-            # Contents (multiples of Ccom)
-            comment = self.boxContents[4:lcom]
+        # Contents (multiples of Ccom)
+        comment = self.boxContents[4:lcom]
+
+        if rcom == 0:
+            # no validation of binary comment content
+            commentIsValid = True
+            comment = bc.bytesToHex(comment)
+
+        elif rcom == 1:
 
             # Decode to string with Latin encoding, determine if valid ISO
             # 8859-15
@@ -1800,15 +1806,11 @@ class BoxValidator:
                 commentIsValid = True
             else:
                 commentIsValid = False
-        else:
-            # no validation of binary comment content
-            commentIsValid = True
 
         self.testFor("commentIsValid", commentIsValid)
 
-        # Only add comment to characteristics if text (may contain binary data
-        # if rcom is 0!)
-        if rcom == 1:
+        # any non-printable data should have been removed.
+        if commentIsValid:
             self.addCharacteristic("comment", comment)
 
     def validate_sot(self):

--- a/jpylyzer/boxvalidator.py
+++ b/jpylyzer/boxvalidator.py
@@ -1779,25 +1779,30 @@ class BoxValidator:
         rcomIsValid = 0 <= rcom <= 1
         self.testFor("rcomIsValid", rcomIsValid)
 
-        # Contents (multiples of Ccom)
-        comment = self.boxContents[4:lcom]
+        if rcom == 1:
+            # Contents (multiples of Ccom)
+            comment = self.boxContents[4:lcom]
 
-        # Decode to string with Latin encoding, determine if valid ISO 8859-15
+            # Decode to string with Latin encoding, determine if valid ISO
+            # 8859-15
 
-        try:
-            comment = comment.decode("iso-8859-15", "strict")
-        except:
-            # Empty string in case of decode error
-            comment = ""
+            try:
+                comment = comment.decode("iso-8859-15", "strict")
+            except:
+                # Empty string in case of decode error
+                comment = ""
 
-        # Ideally decode above should raise exception if comment is not valid
-        # ISO 8859-15, but this doesn't work. So instead we do this indirectly
-        # by looking for control characters (tab, newline and carriage return
-        # are OK)
-        if bc.removeControlCharacters(comment) == comment:
-            commentIsValid = True
+            # Ideally decode above should raise exception if comment is not
+            # valid ISO 8859-15, but this doesn't work. So instead we do this
+            # indirectly by looking for control characters (tab, newline and
+            # carriage return are OK)
+            if bc.removeControlCharacters(comment) == comment:
+                commentIsValid = True
+            else:
+                commentIsValid = False
         else:
-            commentIsValid = False
+            # no validation of binary comment content
+            commentIsValid = True
 
         self.testFor("commentIsValid", commentIsValid)
 


### PR DESCRIPTION
Not sure if commentIsValid is even useful to set for the binary comment case, but I think this is the most backward-compatible fix.
