### PR TITLE
Jython compatibility

### DIFF
--- a/jpylyzer/jpylyzer.py
+++ b/jpylyzer/jpylyzer.py
@@ -33,7 +33,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-import mmap
 import os
 import time
 import imp
@@ -272,6 +271,7 @@ def fileToMemoryMap(file):
     platform = config.PLATFORM
 
     try:
+        import mmap
         if platform == "win32":
             # Parameters for Windows may need further fine-tuning ...
             fileData = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
@@ -337,10 +337,13 @@ def checkOneFile(file):
     
     try:
         # Contents of file to memory map object
-        fileData = fileToMemoryMap(file)
+        try:
+          fileData = fileToMemoryMap(file)
+        except:
+          fileData = readFileBytes(file)
         isValidJP2, tests, characteristics = BoxValidator("JP2", fileData).validate()
         
-        if fileData != "":
+        if fileData != "" and type(fileData) != str:
             fileData.close()
 
         # Generate property values remap table

--- a/jpylyzer/six.py
+++ b/jpylyzer/six.py
@@ -644,7 +644,7 @@ else:
     # Workaround for standalone backslash
 
     def u(s):
-        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+        return unicode(s.replace(r'\\', r'\\\\'), "utf-8")
     unichr = unichr
     int2byte = chr
 


### PR DESCRIPTION
For reference, following on from issue #95, this is how I've got it working under Jython. The main thing is to allow a fail-over to using a byte array when mmap doesn't work.

However, I also found I had to change a bit of unicode escape logic and I don't really know why. If I use the original code, this happens:

```
$ java -jar ~/Downloads/jython-standalone-2.7.0.jar ./jpylyzer/jpylyzer.py vdc_100022551931.0x000001 
<?xml version='1.0' encoding='UTF-8'?>
Traceback (most recent call last):
  File "./jpylyzer/jpylyzer.py", line 732, in <module>
    main()
  File "./jpylyzer/jpylyzer.py", line 728, in main
    checkFiles(args.inputRecursiveFlag, args.inputWrapperFlag, jp2In)
  File "./jpylyzer/jpylyzer.py", line 654, in checkFiles
    xmlElement = checkOneFile(path)
  File "./jpylyzer/jpylyzer.py", line 315, in checkOneFile
    fileNameCleaned = stripSurrogatePairs(fileName)
  File "./jpylyzer/jpylyzer.py", line 435, in stripSurrogatePairs
    lone = re.compile(
  File "/Users/andy/Documents/workspace/jpylyzer/jpylyzer/six.py", line 647, in u
    return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
UnicodeDecodeError: 'unicodeescape' codec can't decode bytes in position 115-121: illegal Unicode character
```

`unicode(s.replace(r'\\', r'\\\\'), "utf-8")` rather than `unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")` it works fine. AFAICT.

One remaining oddity if that the pretty-printing under the Jython `minidom` library behaves slightly differently (as described in [this post](http://ronrothman.com/public/leftbraned/xml-dom-minidom-toprettyxml-and-silly-whitespace/) which indicates this may be old Python behaviour that Jython still observes even through CPython does not). But this is not a problem and the output is identical if pretty-printing is disabled.
