### PR TITLE
FIX - Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 before_install:
   - sudo -H pip install pyinstaller
 
-install:
+script:
   - ./build-with-pyinstaller.sh
 
 after_success:


### PR DESCRIPTION
I had a few tries here but in essence the travis build now runs the supplied build script and then tries to execute the built binary to see the version number. This is a bare bones level of testing but establishes that the build script works.

Fixes #104 