### PR TITLE
FEAT - Multi-architecture, multi-Python builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
 
 services:

--- a/Dockerfile-Wine.build
+++ b/Dockerfile-Wine.build
@@ -17,7 +17,6 @@ ARG CODENAME
 ARG PKGNAME
 ARG VERSION
 
-RUN dpkg --add-architecture i386
 
 # Install build tools and package build deps including nodejs
 RUN env LANG=C apt-get update -qq -o Acquire::Languages=none \
@@ -26,11 +25,26 @@ RUN env LANG=C apt-get update -qq -o Acquire::Languages=none \
         \
         apt-transport-https \
         apt-utils \
+        ca-certificates \
+        gnupg \
         p7zip-full \
+        software-properties-common \
         tar \
+        unzip \
         wget \
-        wine \
         zip
+
+RUN dpkg --add-architecture i386
+
+RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key
+RUN apt-key add winehq.key
+RUN apt-add-repository https://dl.winehq.org/wine-builds/debian/
+
+RUN env LANG=C apt-get update -qq -o Acquire::Languages=none \
+    && env LANG=C DEBIAN_FRONTEND=noninteractive apt-get install \
+        -yqq --install-recommends -o Dpkg::Options::=--force-unsafe-io \
+        \
+        winehq-stable
 
 ENV DISPLAY :0.0
 

--- a/docker-package-win.sh
+++ b/docker-package-win.sh
@@ -21,4 +21,5 @@ docker build --tag $tag \
     --build-arg "VERSION=$pypi_version" \
     -f Dockerfile-Wine.build \
     "$@" .
-docker run -v "$PWD/dist":/dist $tag ls -alh ..\
+    mkdir -p dist
+docker run -v "$PWD/dist":/dist --rm $tag cp --force --recursive dist/win32 dist/win64 /dist

--- a/docker-package.sh
+++ b/docker-package.sh
@@ -24,5 +24,5 @@ docker build --tag $tag \
     -f Dockerfile.build \
     "$@" .
 mkdir -p dist
-docker run -v "$PWD/dist":/dist --rm $tag mv -f "../python-jpylyzer-doc_${deb_version}_all.deb" "../python-jpylyzer_${deb_version}_all.deb" "../python3-jpylyzer_${deb_version}_all.deb" /dist
+docker run -v "$PWD/dist":/dist --rm $tag cp --force "../python-jpylyzer-doc_${deb_version}_all.deb" "../python-jpylyzer_${deb_version}_all.deb" "../python3-jpylyzer_${deb_version}_all.deb" /dist
 ls -lh dist/python?*${pkgname}?*${deb_version//./?}*.*


### PR DESCRIPTION
- refactored `buildwin.sh`:
  * now builds 32 and 64 bit packages for Python3 and Python2;
  * removed all repetition of path and environment creation through use of helper functions;
  * now uses two discrete wine environments, `win64`  and `win32` for separate architecture builds;
  * factored build stages to take out repetition; and
  * eased path of WinPython updates;
- changes to `Dockerfile-Wine.build`:
  * delayed install of wine until MULTIARCH effective;
  * now using official wine from https://dl.winehq.org/; and
- docker builds now copy build artefacts to host.