### PR TITLE
FEAT - Python 3 windows only

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -33,9 +33,6 @@ RUN env LANG=C apt-get update -qq -o Acquire::Languages=none \
         libparse-debianchangelog-perl \
         lintian \
         lsb-release \
-        python-all \
-        python-pip \
-        python-setuptools \
         python3-all \
         python3-dev \
         python3-pip \
@@ -44,11 +41,8 @@ RUN env LANG=C apt-get update -qq -o Acquire::Languages=none \
         tar \
         libxml2-dev
 
-RUN pip install pytest
 RUN pip3 install pytest
 
 WORKDIR /dpkg-build
 COPY ./ ./
 RUN dpkg-buildpackage -tc
-# \
-#    &&  lintian ../python-jpylyzer_*.deb

--- a/buildwin.sh
+++ b/buildwin.sh
@@ -6,9 +6,6 @@
 # Precondition: 64-bit version of Wine is already installed.
 export DISPLAY=:0.0
 # WinPython download URLS
-python2Major=2
-python2Minor=7
-winPython2build="13.1"
 python3Major=3
 python3Minor=5
 winPython3build="4.2"
@@ -121,7 +118,7 @@ buildBinaries(){
     WINEDEBUG=$WineDebug WINEPREFIX=$(winePrefix $bitness) wine $pyInstallerWine $specFile --distpath=$distDir
 
     # Generate name for ZIP file
-    zipName="${scriptBaseName}_${version}_Python${pythonMajor}_win${bitness}.zip"
+    zipName="${scriptBaseName}_${version}_win${bitness}.zip"
     echo "Zip name is $zipName"
     echo ""
     echo "Creating ZIP file ${zipName} from ${scriptBaseName}"
@@ -172,7 +169,5 @@ installAndBuild(){
 # Create Win32 architecture
 WINEARCH=$(winArch 32) WINEPREFIX=$(winePrefix 32) winecfg
 WINEARCH=$(winArch 64) WINEPREFIX=$(winePrefix 64) winecfg
-installAndBuild 64 $python2Major $python2Minor $winPython2build
-installAndBuild 32 $python2Major $python2Minor $winPython2build
 installAndBuild 64 $python3Major $python3Minor $winPython3build
 installAndBuild 32 $python3Major $python3Minor $winPython3build

--- a/debian/control
+++ b/debian/control
@@ -14,15 +14,3 @@ Description: JP2 (JPEG 2000 Part 1) validator and properties extractor.
  images. Jpylyzer was specifically created to check that a JP2 file really
  conforms to the format's specifications. Additionally jpylyzer is able to
  extract the technical characteristics of each image.
-
-
-Package: python-jpylyzer-doc
-Architecture: all
-Depends: ${misc:Depends}
-Description: JP2 (JPEG 2000 Part 1) validator and properties extractor.
- Validator and feature extractor for JP2 (JPEG 2000 Part 1 - ISO/IEC 15444‐1)
- images. Jpylyzer was specifically created to check that a JP2 file really
- conforms to the format's specifications. Additionally jpylyzer is able to
- extract the technical characteristics of each image.
- .
- This is the common documentation package.

--- a/docker-package-win.sh
+++ b/docker-package-win.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Get build platform as 1st argument, and collect project metadata
-image="${1:?You MUST provide a docker image name}"; shift
+image="${1:?You MUST provide a docker image name e.g. debian:stretch}"; shift
 dist_id=${image%%:*}
 codename=${image#*:}
 pypi_name="$(./setup.py --name)"

--- a/docker-package.sh
+++ b/docker-package.sh
@@ -46,7 +46,7 @@ function getDebianVersionString {
 set -e
 
 # Get build platform as 1st argument, and collect project metadata
-image="${1:?You MUST provide a docker image name}"; shift
+image="${1:?You MUST provide a docker image name e.g. debian:stretch}"; shift
 dist_id=${image%%:*}
 codename=${image#*:}
 pypi_name="$(./setup.py --name)"


### PR DESCRIPTION
- removed unnecessary Python2 dependencies from `Dockerfile.build`;
- no more Python2 builds for Windows;
- Python3 install for `pytest`; and
- added minor help for machine architecture in packaging shell scripts.