### PR TITLE
FIX - Windows Docker file permissions

### DIFF
--- a/docker-package-win.sh
+++ b/docker-package-win.sh
@@ -32,7 +32,7 @@ function buildAndPackage(){
     #       https://docs.docker.com/engine/reference/run/#volume-shared-filesystems
     docker run -v "$(pwd):/src/" --name temp-container "cdrx/pyinstaller-windows:${1}"
     docker commit temp-container temp-image
-    docker run  -v "$(pwd):/src/" --rm temp-image "chown 1000 -R /src/dist"
+    docker run  -v "$(pwd):/src/" --rm temp-image "chown $(id -u):$(id -g) -R /src/dist"
     docker container rm temp-container
     docker image rm temp-image
     # Zip up the package and clean up

--- a/docker-package-win.sh
+++ b/docker-package-win.sh
@@ -30,7 +30,7 @@ function buildAndPackage(){
     #       https://docs.docker.com/engine/reference/run/#clean-up---rm
     # -v "$(pwd):/src/" Map working directory to container /src:
     #       https://docs.docker.com/engine/reference/run/#volume-shared-filesystems
-    docker run -v "$(pwd):/src/" --user "$(id -u)":"$(id -g)" --rm "cdrx/pyinstaller-windows:${1}"
+    docker run -v "$(pwd):/src/" --rm "cdrx/pyinstaller-windows:${1}" "/entrypoint.sh && chown $(id -u):$(id -g) -R /src/dist"
 
     # Zip up the package and clean up
     cd "${WIN_DIST_DIR}"

--- a/docker-package-win.sh
+++ b/docker-package-win.sh
@@ -30,6 +30,8 @@ function buildAndPackage(){
     #       https://docs.docker.com/engine/reference/run/#clean-up---rm
     # -v "$(pwd):/src/" Map working directory to container /src:
     #       https://docs.docker.com/engine/reference/run/#volume-shared-filesystems
+    docker stop temp-container || true && docker rm temp-container || true
+    docker image rm temp-image || true
     docker run -v "$(pwd):/src/" --name temp-container "cdrx/pyinstaller-windows:${1}"
     docker commit temp-container temp-image
     docker run  -v "$(pwd):/src/" --rm temp-image "chown $(id -u):$(id -g) -R /src/dist"

--- a/docker-package-win.sh
+++ b/docker-package-win.sh
@@ -30,13 +30,8 @@ function buildAndPackage(){
     #       https://docs.docker.com/engine/reference/run/#clean-up---rm
     # -v "$(pwd):/src/" Map working directory to container /src:
     #       https://docs.docker.com/engine/reference/run/#volume-shared-filesystems
-    docker stop temp-container || true && docker rm temp-container || true
-    docker image rm temp-image || true
-    docker run -v "$(pwd):/src/" --name temp-container "cdrx/pyinstaller-windows:${1}"
-    docker commit temp-container temp-image
-    docker run  -v "$(pwd):/src/" --rm temp-image "chown $(id -u):$(id -g) -R /src/dist"
-    docker container rm temp-container
-    docker image rm temp-image
+    docker run -v "$(pwd):/src/" --rm "cdrx/pyinstaller-windows:${1}" "/entrypoint.sh && chown $(id -u):$(id -g) -R /src/dist"
+
     # Zip up the package and clean up
     cd "${WIN_DIST_DIR}"
     zip -r ${zip_name} ${pkgname}

--- a/docker-package-win.sh
+++ b/docker-package-win.sh
@@ -30,7 +30,7 @@ function buildAndPackage(){
     #       https://docs.docker.com/engine/reference/run/#clean-up---rm
     # -v "$(pwd):/src/" Map working directory to container /src:
     #       https://docs.docker.com/engine/reference/run/#volume-shared-filesystems
-    docker run -v "$(pwd):/src/" --rm "cdrx/pyinstaller-windows:${1}" "/entrypoint.sh && chown $(id -u):$(id -g) -R /src/dist"
+    docker run -v "$(pwd):/src/" --user "$(id -u)":"$(id -g)" --rm "cdrx/pyinstaller-windows:${1}"
 
     # Zip up the package and clean up
     cd "${WIN_DIST_DIR}"


### PR DESCRIPTION
- use `id` utility to deduce running process uid and default group id for Docker `chown` command; and
- the container is still run in a single invocation with chained commands.

@bitsgalore, you probably don't need to do the PyPi thing for this but if you do I'd suggest [a post release](https://www.python.org/dev/peps/pep-0440/#post-releases).