### PR TITLE
Add explicit error on opening large file with 32-bit python

### DIFF
--- a/jpylyzer/jpylyzer.py
+++ b/jpylyzer/jpylyzer.py
@@ -279,8 +279,8 @@ def fileToMemoryMap(filename):
             fileSize = os.path.getsize(filename)
             if fileSize > sys.maxsize:
                 shared.printWarning("The file is too large to open (" +
-                             str(round(fileSize/1024**3, 1)) +
-                             " GB). Try using 64-bit python.")
+                                    str(round(fileSize/1024**3, 1)) +
+                                    " GB). Try using 64-bit python.")
             shared.errorExit("Opening file failed: " + str(e))
             # mmap fails on empty files.
             fileData = ""


### PR DESCRIPTION
Previously opening a file that's too large would just report the file as invalid. With this PR the user will see a message like:
```
User warning: The file is too large to open (5.9 GB). Try using 64-bit python.
Error: Opening file failed: mmap length is too large
```

This may sound like an edge case, but geospatial jp2s are often going to be too large for 32-bit python to handle.

Of course there is another issue in that this program reads the entire file into memory, which is going to be problematic for really large files, but this is a start.

I also changed `open` to `with open` to ensure the file is closed on failure.