### PR TITLE
Add plt, plm segments to properties output

### DIFF
--- a/jpylyzer/boxvalidator.py
+++ b/jpylyzer/boxvalidator.py
@@ -2368,7 +2368,9 @@ class BoxValidator:
         """Empty function."""
     def validate_plt(self):
         """Packet length, tile-part header (PLT) marker segment (ISO/IEC 15444-1 Section A.7.3).
-        Currently performs no validation, just adds details properties XML"""
+        
+        Currently performs no validation, just adds details to properties XML.
+        """
 
         # Length of PLT marker
         lplt = bc.bytesToUShortInt(self.boxContents[0:2])

--- a/jpylyzer/boxvalidator.py
+++ b/jpylyzer/boxvalidator.py
@@ -2367,8 +2367,8 @@ class BoxValidator:
     def validate_plm(self):
         """Empty function."""
     def validate_plt(self):
-        """Packet length, tile-part header (PLT) marker segment (ISO/IEC 15444-1 Section A.7.3)."""
-        """Currently performs no validation, just adds details properties XML"""
+        """Packet length, tile-part header (PLT) marker segment (ISO/IEC 15444-1 Section A.7.3).
+        Currently performs no validation, just adds details properties XML"""
 
         # Length of PLT marker
         lplt = bc.bytesToUShortInt(self.boxContents[0:2])
@@ -2391,7 +2391,7 @@ class BoxValidator:
         i = 3    # 3 = sizeof(zplt) + sizeof(lplt). Skip to start reading at lplt.
         while i < lplt and i < len(self.boxContents):   # Don't over-read on bad lplt
             iplt_i_len = 1    # number of bytes making up the current iplt_i
-            while bc.bytesToUnsignedChar(self.boxContents[i+iplt_i_len-1:i+iplt_i_len]) & 0b10000000:
+            while bc.bytesToUnsignedChar(self.boxContents[i+iplt_i_len-1:i+iplt_i_len]) & 0x80:
                 iplt_i_len += 1
 
             # Join all the segments together

--- a/jpylyzer/boxvalidator.py
+++ b/jpylyzer/boxvalidator.py
@@ -2368,10 +2368,9 @@ class BoxValidator:
         """Empty function."""
     def validate_plt(self):
         """Packet length, tile-part header (PLT) marker segment (ISO/IEC 15444-1 Section A.7.3).
-        
+
         Currently performs no validation, just adds details to properties XML.
         """
-
         # Length of PLT marker
         lplt = bc.bytesToUShortInt(self.boxContents[0:2])
         self.addCharacteristic("lplt", lplt)

--- a/jpylyzer/boxvalidator.py
+++ b/jpylyzer/boxvalidator.py
@@ -227,9 +227,9 @@ class BoxValidator:
         shift = wordLength - p
 
         return (n >> shift) & 1
-    
+
     def _parse_ipl(self, lpl, offset):
-        """Parses Iplt/Iplm parameters into a comma separated string of (hex) values.
+        """Parse Iplt/Iplm parameters into a comma separated string of (hex) values.
 
         The logic here is basically:
         Each iplt/iplm is a collection of 7 bits, where the MSB signifies the following 7 bits

--- a/jpylyzer/boxvalidator.py
+++ b/jpylyzer/boxvalidator.py
@@ -2382,8 +2382,8 @@ class BoxValidator:
         # Each iplt is a collection of 7 bits, where the MSB signifies the following 7 bits
         # are to be prepended to the following 7 LSB bits.
         # Eg: boxContents = [0C,9F,62,7C] becomes [0C,FE2,7C], as
-        # 9F  = ‭10011111‬
-        # 62  =        01100010‬
+        # 9F  = 10011111
+        # 62  =        01100010
         # FE2 = 000111111100010
         # See table A.36 for more details.
         # Same logic as Iplm section (A.7.2), so could be moved to it's own function


### PR DESCRIPTION
I didn't add any validation, as for large files this could take up a significant percentage of the output file.
This will significantly increase the output size for datasets that use plt's. The output of a ~6GB file with plt's went from ~90KB to ~90MB.

The logic here could also be used to parse the plm segment. However I don't have any sample datastes that use that, so I didn't implement this.